### PR TITLE
Add Windows frontend build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It works out-of-the-box.
 Install the front-end dependencies.
 
 ```
-cd front && npm install
+sbt frontEndBuild
 ```
 
 Launch the project

--- a/build.sbt
+++ b/build.sbt
@@ -32,11 +32,14 @@ cleanFrontEndBuild := {
 
 lazy val frontEndBuild = taskKey[Unit]("Execute the npm build command to build the front-end")
 
+val buildCommandPrefix = sys.props.get("os.name").filter(_.toUpperCase.contains("WIN")).map(_ => "cmd /c npm").getOrElse("npm")
+
 frontEndBuild := {
-  println(Process("npm install", file("front")).!!)
-  println(Process("npm run build", file("front")).!!)
+  println(Process(s"$buildCommandPrefix install", file("front")).!!)
+  println(Process(s"$buildCommandPrefix run build", file("front")).!!)
 }
 
 frontEndBuild := (frontEndBuild dependsOn cleanFrontEndBuild).value
 
+stage := (stage dependsOn frontEndBuild).value
 dist := (dist dependsOn frontEndBuild).value


### PR DESCRIPTION
This PR adds support for installing frontend dependencies directly in SBT under Windows OS (thus possibility to stage/deploy as well)